### PR TITLE
make bongo cat not stretch and keep aspect ratio

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,7 +67,7 @@ class BongoCatViewProvider implements vscode.WebviewViewProvider {
 		  <title>Bongo Cat</title>
 		  <style>
 			  body { margin: 0; padding: 0; display: flex; justify-content: center; align-items: center; height: 100vh; }
-			  img { max-width: 100%; max-height: 100%; }
+			  img { max-width: 100%; max-height: 100%; object-fit: contain }
 		  </style>
 	  </head>
 	  <body>


### PR DESCRIPTION
Not a webdev. Did not run the tests - don't have the time as of writing.

Just wanted to raise awareness to this issue by proposing a fix (that I'll test if no one else beats me to it)

<img width="683" alt="image" src="https://github.com/user-attachments/assets/333169b0-13d2-40b6-946b-16cf42259ec6" />

bongo cat stretches and gets wide. hopefully this fixes it 🤞🏼 